### PR TITLE
Add support for `--token-usage`/`-u` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ Note: Use `npm start -- -option` to pass the option flag to the program, as npm 
   npm start file.js -- -t 1.1
   ```
 
+- `-u, --token-usage`: Display token usage information
+
+  ```bash
+  npm start file.js -- -u
+  ```
+
 ### Additional Commands
 
 - **Check Version:** To check the current version of the tool, use:

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -49,6 +49,13 @@ const aiResponse = async (data: string): Promise<void> => {
         console.log(`Documented code written to ${program.opts().output}`);
       } else {
         console.log(completion.choices[0].message.content);
+        //display token usage if requested
+        if (program.opts().tokenUsage) {
+          console.error('Token Usage:\n',
+            `Completion Tokens: ${completion.usage?.completion_tokens}\n`,
+            `Prompt Tokens: ${completion.usage?.prompt_tokens}\n`,
+            `Total Tokens: ${completion.usage?.total_tokens}\n`);
+        }
       }
     } catch (error: any) {
       if (error.code === 400) {

--- a/src/program.ts
+++ b/src/program.ts
@@ -14,6 +14,7 @@ program
   )
   .option('-o,--output <output-file>', 'file to output response') // Option to specify the output file
   .option('-t, --temperature <temperature>', 'set the model temperature', '0.5') // Option to set the model temperature
+  .option('-u, --token-usage', 'output token usage data') // Option to display token usage data
   .argument('<files...>') // Define the required file argument
   .action(async function (files: string[]) {
     //Loop through files and process them


### PR DESCRIPTION
Fixes #6.

Some considerations:

- I used the `-u` short flag since `-t` was in use.
- This implementation does not print token usage if the `-o` flag is used.